### PR TITLE
DRAFT: Updated timing metadata for the query container

### DIFF
--- a/query-container/publish-api/src/publisher.rs
+++ b/query-container/publish-api/src/publisher.rs
@@ -61,7 +61,7 @@ impl Publisher {
         let mut connection = self.connection.clone();
         let mut items = Vec::with_capacity(4);
         let now = match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-            Ok(now) => now.as_millis().to_string(),
+            Ok(now) => now.as_nanos().to_string(),
             Err(e) => {
                 return Err(PublishError::Other(format!(
                     "Error getting current time: {}",

--- a/query-container/query-host/src/change_stream/mod.rs
+++ b/query-container/query-host/src/change_stream/mod.rs
@@ -23,6 +23,7 @@ pub mod publisher;
 pub struct Message<T> {
     pub id: String,
     pub data: T,
+    pub enqueue_time: u64,
     pub trace_state: Option<String>,
     pub trace_parent: Option<String>,
 }

--- a/query-container/query-host/src/change_stream/publisher.rs
+++ b/query-container/query-host/src/change_stream/publisher.rs
@@ -63,7 +63,7 @@ impl Publisher {
         let now = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
-            .as_millis()
+            .as_nanos()
             .to_string();
         items.push(("data", data));
         items.push(("enqueue_time", now));

--- a/query-container/query-host/src/change_stream/redis_change_stream.rs
+++ b/query-container/query-host/src/change_stream/redis_change_stream.rs
@@ -308,6 +308,25 @@ where
             },
             None => None,
         },
+        enqueue_time: match message.map.get("enqueue_time") {
+            Some(data) => match data {
+                redis::Value::Data(data) => match String::from_utf8(data.to_vec()) {
+                    Ok(data_str) => match data_str.parse::<u64>() {
+                        Ok(parsed) => parsed,
+                        Err(err) => {
+                            log::error!("Failed to parse enqueue_time to u64: {:?}", err);
+                            0
+                        }
+                    },
+                    Err(err) => {
+                        log::error!("Failed to deserialize enqueue_time to String: {:?}", err);
+                        0
+                    }
+                },
+                _ => 0,
+            },
+            None => 0,
+        },        
     })
 }
 

--- a/query-container/query-host/src/query_worker.rs
+++ b/query-container/query-host/src/query_worker.rs
@@ -256,7 +256,7 @@ impl QueryWorker {
             let msg_latency = meter
                 .f64_histogram("drasi.query-host.msg_latency")
                 .with_description("Latency of messge processing")
-                .with_unit(opentelemetry::metrics::Unit::new("ms"))
+                .with_unit(opentelemetry::metrics::Unit::new("ns"))
                 .init();
 
             let metric_attributes = [KeyValue::new("query_id", query_id.to_string())];
@@ -341,6 +341,8 @@ impl QueryWorker {
                                 match msg {
                                     None => continue,
                                     Some(evt) => {
+                                        let msg_process_start = Instant::now();
+                                        let enqueue_time = evt.enqueue_time;
                                         if !evt.data.has_query(query_id.as_ref()) {
                                             log::info!("skipping message for another query");
                                             if let Err(err) = change_stream.ack(&evt.id).await {
@@ -348,15 +350,14 @@ impl QueryWorker {
                                             }
                                             continue;
                                         }
-
-                                        let msg_process_start = Instant::now();
+                                   
                                         let parent_context = trace_propogator.extract(&evt);
                                         let span = tracing::span!(tracing::Level::INFO, "process_message");
                                         span.set_parent(parent_context);
                                         span.set_attribute("query_id", query_id.clone());
 
                                         let evt_id = &evt.id.clone();
-                                        let process_future = process_change(&query_id, &continuous_query, &mut sequence_manager, &publisher, evt)
+                                        let process_future = process_change(&query_id, &continuous_query, &mut sequence_manager, &publisher, evt, enqueue_time)
                                             .instrument(span);
 
                                         match process_future.await {
@@ -373,7 +374,7 @@ impl QueryWorker {
                                             tracing::error!("Error acknowledging message: {}", err);
                                         }
 
-                                        msg_latency.record(msg_process_start.elapsed().as_secs_f64() * 1000.0, &metric_attributes);
+                                        msg_latency.record(msg_process_start.elapsed().as_nanos() as f64, &metric_attributes);
                                         change_counter.add(1, &metric_attributes);
                                     }
                                 }
@@ -467,6 +468,7 @@ async fn process_change(
     seq_manager: &mut SequenceManager,
     publisher: &ResultPublisher,
     evt: Message<ChangeEvent>,
+    enqueue_time: u64,
 ) -> Result<(), Box<dyn std::error::Error>> {
     log::info!("Query {} received message: {:?}", query_id, evt);
     let dequeue_time = SystemTime::now();
@@ -502,25 +504,26 @@ async fn process_change(
                 dequeue_time
                     .duration_since(UNIX_EPOCH)
                     .unwrap_or_default()
-                    .as_millis() as u64,
+                    .as_nanos() as u64,
             );
             let query_start_time = Number::from(
                 process_start_time
                     .duration_since(UNIX_EPOCH)
                     .unwrap_or_default()
-                    .as_millis() as u64,
+                    .as_nanos() as u64,
             );
             let query_end_time = Number::from(
                 process_end_time
                     .duration_since(UNIX_EPOCH)
                     .unwrap_or_default()
-                    .as_millis() as u64,
+                    .as_nanos() as u64,
             );
 
             let mut qt = Map::new();
-            qt.insert("dequeue_ms".to_string(), Value::Number(dequeue_time));
-            qt.insert("queryStart_ms".to_string(), Value::Number(query_start_time));
-            qt.insert("queryEnd_ms".to_string(), Value::Number(query_end_time));
+            qt.insert("dequeue_ns".to_string(), Value::Number(dequeue_time));
+            qt.insert("enqueue_ns".to_string(), Value::Number(Number::from(enqueue_time)));
+            qt.insert("queryStart_ns".to_string(), Value::Number(query_start_time));
+            qt.insert("queryEnd_ns".to_string(), Value::Number(query_end_time));
 
             tracking.insert("query".to_string(), Value::Object(qt));
         }

--- a/query-container/view-svc/src/mongo_view_store.rs
+++ b/query-container/view-svc/src/mongo_view_store.rs
@@ -349,12 +349,12 @@ impl ViewStore for MongoViewStore {
         let now = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
-            .as_millis() as u64;
+            .as_nanos() as u64;
         let timestamp = timestamp.unwrap_or(now) as i64;
         let effective_at = std::cmp::min(metadata.ts, timestamp);
 
         if let RetentionPolicy::Expire { after_seconds } = policy {
-            if ((now - (after_seconds * 1000)) as i64) > timestamp {
+            if ((now - (after_seconds * 1_000_000_000)) as i64) > timestamp {
                 return Err(ViewError::NotFound);
             }
         }
@@ -518,12 +518,12 @@ async fn collect_garbage(store: Arc<MongoViewStore>) {
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
-        .as_millis() as i64;
+        .as_nanos() as i64;
 
     for (query_id, policy) in policy_snapshot {
         let epoch = match policy {
             RetentionPolicy::Latest => continue,
-            RetentionPolicy::Expire { after_seconds } => now - (after_seconds as i64 * 1000),
+            RetentionPolicy::Expire { after_seconds } => now - (after_seconds as i64 * 1_000_000_000),
             RetentionPolicy::All => continue,
         };
 

--- a/query-container/view-svc/src/mongo_view_store.rs
+++ b/query-container/view-svc/src/mongo_view_store.rs
@@ -349,12 +349,12 @@ impl ViewStore for MongoViewStore {
         let now = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
-            .as_nanos() as u64;
+            .as_millis() as u64;
         let timestamp = timestamp.unwrap_or(now) as i64;
         let effective_at = std::cmp::min(metadata.ts, timestamp);
 
         if let RetentionPolicy::Expire { after_seconds } = policy {
-            if ((now - (after_seconds * 1_000_000_000)) as i64) > timestamp {
+            if ((now - (after_seconds * 1000)) as i64) > timestamp {
                 return Err(ViewError::NotFound);
             }
         }
@@ -518,12 +518,12 @@ async fn collect_garbage(store: Arc<MongoViewStore>) {
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
-        .as_nanos() as i64;
+        .as_millis() as i64;
 
     for (query_id, policy) in policy_snapshot {
         let epoch = match policy {
             RetentionPolicy::Latest => continue,
-            RetentionPolicy::Expire { after_seconds } => now - (after_seconds as i64 * 1_000_000_000),
+            RetentionPolicy::Expire { after_seconds } => now - (after_seconds as i64 * 1000),
             RetentionPolicy::All => continue,
         };
 

--- a/query-container/view-svc/src/view_worker.rs
+++ b/query-container/view-svc/src/view_worker.rs
@@ -101,7 +101,7 @@ impl ViewWorker {
             let msg_latency = meter
                 .f64_histogram("drasi.view-svc.msg_latency")
                 .with_description("Latency of messge processing")
-                .with_unit(opentelemetry::metrics::Unit::new("ms"))
+                .with_unit(opentelemetry::metrics::Unit::new("ns"))
                 .init();
 
             let metric_attributes = [KeyValue::new("query_id", query_id.to_string())];
@@ -180,7 +180,7 @@ impl ViewWorker {
                                             log::error!("Error acknowledging message: {}", err);
                                         }
 
-                                        msg_latency.record(msg_process_start.elapsed().as_secs_f64() * 1000.0, &metric_attributes);
+                                        msg_latency.record(msg_process_start.elapsed().as_nanos() as f64, &metric_attributes);
                                     }
                                 }
                             }


### PR DESCRIPTION
# Description

- Updated the precision of the timing metadata to be in nanoseconds. The metadata will have four pieces of information: `enqueue_ns` (from the publish API), `dequeue_ns`, `queryStart_ns` and `queryEnd_ns`.
- Updated the enqueue time in publish_api to use nanoseconds


## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
